### PR TITLE
Parallel to LoopKit PR 21: Add link to Dexcom app in G7 settings

### DIFF
--- a/G7SensorKitUI/Views/G7SettingsView.swift
+++ b/G7SensorKitUI/Views/G7SettingsView.swift
@@ -123,6 +123,14 @@ struct G7SettingsView: View {
                     Toggle(LocalizedString("Upload Readings", comment: "title for g7 config settings to upload readings"), isOn: $viewModel.uploadReadings)
                 }
             }
+            
+            Section () {
+                Button(LocalizedString("Open Dexcom App", comment:"Opens the dexcom G7 app to allow users to manage active sensors"), action: {
+                    if let appURL = URL(string: "dexcomg7://") {
+                        UIApplication.shared.open(appURL)
+                    }
+                })
+            }
 
             Section () {
                 if !self.viewModel.scanning {


### PR DESCRIPTION
I found myself missing the 'Open app' button from the G6, and that my muscle memory kept expecting it to be there, so in this PR I've added it into the G7 management screen.

I opted to create a new section rather than include it with the other management buttons beneath to try to prevent users accidentally tapping the more destructive actions.

see https://github.com/LoopKit/G7SensorKit/pull/21