### PR TITLE
Update for pr34

### DIFF
--- a/G7SensorKit/AlgorithmError.swift
+++ b/G7SensorKit/AlgorithmError.swift
@@ -37,12 +37,14 @@ extension AlgorithmState {
                 return LocalizedString("Sensor is OK", comment: "The description of sensor algorithm state when sensor is ok.")
             case .stopped:
                 return LocalizedString("Sensor is stopped", comment: "The description of sensor algorithm state when sensor is stopped.")
-            case .warmup, .questionMarks:
+            case .warmup, .temporarySensorIssue:
                 return LocalizedString("Sensor is warming up", comment: "The description of sensor algorithm state when sensor is warming up.")
             case .expired:
                 return LocalizedString("Sensor expired", comment: "The description of sensor algorithm state when sensor is expired.")
             case .sensorFailed:
                 return LocalizedString("Sensor failed", comment: "The description of sensor algorithm state when sensor failed.")
+            default:
+                return "Sensor state: \(String(describing: state))"
             }
         case .unknown(let rawValue):
             return String(format: LocalizedString("Sensor is in unknown state %1$d", comment: "The description of sensor algorithm state when raw value is unknown. (1: missing data details)"), rawValue)

--- a/G7SensorKit/AlgorithmState.swift
+++ b/G7SensorKit/AlgorithmState.swift
@@ -15,10 +15,29 @@ public enum AlgorithmState: RawRepresentable {
     public enum State: RawValue {
         case stopped = 1
         case warmup = 2
+        case excessNoise = 3
+        case firstOfTwoBGsNeeded = 4
+        case secondOfTwoBGsNeeded = 5
         case ok = 6
-        case questionMarks = 18
+        case needsCalibration = 7
+        case calibrationError1 = 8
+        case calibrationError2 = 9
+        case calibrationLinearityFitFailure = 10
+        case sensorFailedDuetoCountsAberration = 11
+        case sensorFailedDuetoResidualAberration = 12
+        case outOfCalibrationDueToOutlier = 13
+        case outlierCalibrationRequest = 14
+        case sessionExpired = 15
+        case sessionFailedDueToUnrecoverableError = 16
+        case sessionFailedDueToTransmitterError = 17
+        case temporarySensorIssue = 18
+        case sensorFailedDueToProgressiveSensorDecline = 19
+        case sensorFailedDueToHighCountsAberration = 20
+        case sensorFailedDueToLowCountsAberration = 21
+        case sensorFailedDueToRestart = 22
         case expired = 24
         case sensorFailed = 25
+        case sessionEnded = 26
     }
 
     case known(State)
@@ -48,7 +67,7 @@ public enum AlgorithmState: RawRepresentable {
         }
 
         switch state {
-        case .sensorFailed:
+        case .sensorFailed, .sensorFailedDuetoCountsAberration, .sensorFailedDuetoResidualAberration, .sessionFailedDueToTransmitterError, .sessionFailedDueToUnrecoverableError, .sensorFailedDueToProgressiveSensorDecline, .sensorFailedDueToHighCountsAberration, .sensorFailedDueToLowCountsAberration, .sensorFailedDueToRestart:
             return true
         default:
             return false
@@ -68,13 +87,13 @@ public enum AlgorithmState: RawRepresentable {
         }
     }
 
-    public var isInSensorError: Bool {
+    public var hasTemporaryError: Bool {
         guard case .known(let state) = self else {
             return false
         }
 
         switch state {
-        case .questionMarks:
+        case .temporarySensorIssue:
             return true
         default:
             return false
@@ -88,14 +107,10 @@ public enum AlgorithmState: RawRepresentable {
         }
 
         switch state {
-        case .stopped,
-             .warmup,
-             .questionMarks,
-             .expired,
-             .sensorFailed:
-            return false
         case .ok:
             return true
+        default:
+            return false
         }
     }
 }

--- a/G7SensorKit/G7CGMManager/G7CGMManager.swift
+++ b/G7SensorKit/G7CGMManager/G7CGMManager.swift
@@ -323,6 +323,11 @@ extension G7CGMManager: G7SensorDelegate {
         }
     }
 
+    public func sensor(_ sensor: G7Sensor, logComms comms: String) {
+        logDeviceCommunication("Sensor comms \(comms)", type: .receive)
+    }
+
+
     public func sensor(_ sensor: G7Sensor, didError error: Error) {
         logDeviceCommunication("Sensor error \(error)", type: .error)
     }
@@ -334,6 +339,17 @@ extension G7CGMManager: G7SensorDelegate {
             updateDelegate(with: .noData)
             return
         }
+
+        if message.algorithmState.sensorFailed {
+            logDeviceCommunication("Detected failed sensor... scanning for new sensor.", type: .receive)
+            scanForNewSensor()
+        }
+
+        if message.algorithmState == .known(.sessionEnded) {
+            logDeviceCommunication("Detected session ended... scanning for new sensor.", type: .receive)
+            scanForNewSensor()
+        }
+
 
         guard let activationDate = sensor.activationDate else {
             logDeviceCommunication("Unable to process sensor reading without activation date.", type: .error)

--- a/G7SensorKit/G7CGMManager/G7CGMManager.swift
+++ b/G7SensorKit/G7CGMManager/G7CGMManager.swift
@@ -237,14 +237,14 @@ public class G7CGMManager: CGMManager {
         return nil
     }
 
-    public func scanForNewSensor(scanAfterDelay: Bool = false) {
+    public func scanForNewSensor() {
         logDeviceCommunication("Forgetting existing sensor and starting scan for new sensor.", type: .connection)
 
         mutateState { state in
             state.sensorID = nil
             state.activatedAt = nil
         }
-        sensor.scanForNewSensor(scanAfterDelay: scanAfterDelay)
+        sensor.scanForNewSensor()
     }
 
     private var device: HKDevice? {
@@ -319,7 +319,7 @@ extension G7CGMManager: G7SensorDelegate {
     public func sensorDisconnected(_ sensor: G7Sensor, suspectedEndOfSession: Bool) {
         logDeviceCommunication("Sensor disconnected: suspectedEndOfSession=\(suspectedEndOfSession)", type: .connection)
         if suspectedEndOfSession {
-            scanForNewSensor(scanAfterDelay: true)
+            scanForNewSensor()
         }
     }
 

--- a/G7SensorKit/G7CGMManager/G7Sensor.swift
+++ b/G7SensorKit/G7CGMManager/G7Sensor.swift
@@ -99,15 +99,11 @@ public final class G7Sensor: G7BluetoothManagerDelegate {
         bluetoothManager.delegate = self
     }
 
-    public func scanForNewSensor(scanAfterDelay: Bool = false) {
+    public func scanForNewSensor() {
         self.sensorID = nil
         bluetoothManager.disconnect()
         bluetoothManager.forgetPeripheral()
-        if scanAfterDelay {
-            bluetoothManager.scanAfterDelay()
-        } else {
-            bluetoothManager.scanForPeripheral()
-        }
+        bluetoothManager.scanForPeripheral()
     }
 
     public func resumeScanning() {

--- a/G7SensorKit/Messages/G7Opcode.swift
+++ b/G7SensorKit/Messages/G7Opcode.swift
@@ -10,6 +10,7 @@ import Foundation
 
 enum G7Opcode: UInt8 {
     case authChallengeRx = 0x05
+    case sessionStopTx = 0x28
     case glucoseTx = 0x4e
     case backfillFinished = 0x59
 }

--- a/G7SensorKitUI/G7CGMManager/G7CGMManager+UI.swift
+++ b/G7SensorKitUI/G7CGMManager/G7CGMManager+UI.swift
@@ -74,7 +74,7 @@ extension G7CGMManager: CGMManagerUI {
                 state: .warning)
         }
 
-        if let latestReading = latestReading, latestReading.algorithmState.isInSensorError {
+        if let latestReading = latestReading, latestReading.algorithmState.hasTemporaryError {
             return G7DeviceStatusHighlight(
                 localizedMessage: LocalizedString("Sensor\nIssue", comment: "G7 Status highlight text for sensor error"),
                 imageName: "exclamationmark.circle.fill",


### PR DESCRIPTION
## Purpose

Update the G7SensorKit loopandlearn fork, trio branch to include the final changes made by LoopKit / G7SensorKit PR 34 to improve G7 connectivity.

## Method

Fix any merge conflicts between the previous PR 33 that did provide some improvements, but has been closed in favor of PR 34.

## Expected code differences

After this merge, expected differences between LoopKit / G7SensorKit main and loopandlearn / G7SensorKit trio is that the trio branch defaults G7 upload to enabled whereas LoopKit has it disabled. Trio has a master upload glucose switch in the Nightscout screen; Loop does not.