### PR TITLE
Fix calibration decoding, and lagged backfill processing

### DIFF
--- a/G7SensorKit/G7CGMManager/G7BackfillMessage.swift
+++ b/G7SensorKit/G7CGMManager/G7BackfillMessage.swift
@@ -32,17 +32,18 @@ public struct G7BackfillMessage: Equatable {
             return nil
         }
 
-        timestamp = data[0..<4].toInt()
+        
+        timestamp = data[0..<3].toInt()
 
         let glucoseBytes = data[4..<6].to(UInt16.self)
 
         if glucoseBytes != 0xffff {
             glucose = glucoseBytes & 0xfff
-            glucoseIsDisplayOnly = (glucoseBytes & 0xf000) > 0
         } else {
             glucose = nil
-            glucoseIsDisplayOnly = false
         }
+
+        glucoseIsDisplayOnly = data[7] & 0x10 != 0
 
         algorithmState = AlgorithmState(rawValue: data[6])
 

--- a/G7SensorKitTests/G7GlucoseMessageTests.swift
+++ b/G7SensorKitTests/G7GlucoseMessageTests.swift
@@ -131,6 +131,23 @@ final class G7GlucoseMessageTests: XCTestCase {
         let data = Data(hexadecimalString: "cf5802008f00060f10")!
         let message = G7BackfillMessage(data: data)!
         XCTAssertEqual(153807, message.timestamp)
+        XCTAssertEqual(143, message.glucose)
+        XCTAssertEqual(.known(.ok), message.algorithmState)
+        XCTAssertNil(message.condition)
+        XCTAssertEqual(false, message.glucoseIsDisplayOnly)
+        XCTAssertEqual(true, message.hasReliableGlucose)
+    }
+
+    func testBackfillTimestampWithHighByte() {
+        let data = Data(hexadecimalString: "f20e0d00ba00060ffb")!
+        let message = G7BackfillMessage(data: data)!
+        XCTAssertEqual(855794, message.timestamp)
+    }
+
+    func testBackfillCalibration() {
+        let data = Data(hexadecimalString: "f63d00008500061efe")!
+        let message = G7BackfillMessage(data: data)!
+        XCTAssertEqual(true, message.glucoseIsDisplayOnly)
     }
 
 }


### PR DESCRIPTION
## Purpose

Update the G7SensorKit loopandlearn fork, `trio` branch to include the bugfix changes made by [LoopKit / G7SensorKit PR 35](https://github.com/LoopKit/G7SensorKit/pull/35) to "Fix calibration decoding, and lagged backfill processing"

## Method

PR 35 consisted of a single commit, so use cherry-pick to apply to this PR branch:

```
git switch trio
git pull
git switch -c update_for_pr35
git cherry-pick 5481bd0014ff09ccaa4cd52c60581b279389fd38
```

Confirm that this branch has only the expected code differences with respect to the `main` branch (which is kept up to date with LoopKit `main` branch.)

## Expected code differences

After this merge, expected differences between LoopKit / G7SensorKit main and loopandlearn / G7SensorKit trio:
* Default for glucose upload: the trio branch defaults G7 upload to enabled whereas LoopKit has it disabled
* PR 32 to add build dependency is not yet merged into LoopKit but is merged into loopandlearn / G7SensorKit trio